### PR TITLE
RCRV-72 AWS에서 각 서비스의 health를 체크할 수 있는 health-check endpoint를 각각 구현한다

### DIFF
--- a/apps/shop-admin/next-env.d.ts
+++ b/apps/shop-admin/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/shop-admin/src/pages/api/health-check.ts
+++ b/apps/shop-admin/src/pages/api/health-check.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+    res.status(200).json({ 
+        status: 'ok', 
+    });
+}

--- a/apps/shop-admin/tsconfig.json
+++ b/apps/shop-admin/tsconfig.json
@@ -2,11 +2,23 @@
   "extends": "@review-canvas/typescript-config/nextjs.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "jsxImportSource": "@emotion/react",
-    "types": ["./src/@types/twin.d.ts"],
+    "types": [
+      "./src/@types/twin.d.ts"
+    ],
+    "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/apps/super-admin/next-env.d.ts
+++ b/apps/super-admin/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/super-admin/pages/api/health-check.ts
+++ b/apps/super-admin/pages/api/health-check.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+    res.status(200).json({ 
+        status: 'ok', 
+    });
+}

--- a/apps/super-admin/tsconfig.json
+++ b/apps/super-admin/tsconfig.json
@@ -2,11 +2,23 @@
   "extends": "@review-canvas/typescript-config/nextjs.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "jsxImportSource": "@emotion/react",
-    "types": ["./src/@types/twin.d.ts"],
+    "types": [
+      "./src/@types/twin.d.ts"
+    ],
+    "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/src/pages/api/health-check.ts
+++ b/apps/web/src/pages/api/health-check.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+    res.status(200).json({ 
+        status: 'ok', 
+    });
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,11 +2,23 @@
   "extends": "@review-canvas/typescript-config/nextjs.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "jsxImportSource": "@emotion/react",
-    "types": ["./src/@types/twin.d.ts"],
+    "types": [
+      "./src/@types/twin.d.ts"
+    ],
+    "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 적용사항
web, shop-admin, super-admin에 각각 `/pages/api/health-check.ts` 파일 생성
* app router를 활용 중이기 때문에 `/app/routes/api/health-check.ts` 로 해 봤는데 404 에러 출력됨.
* 일부 레퍼런스에서 api는 `/pages/api`에 남겨놓는 경우가 있다 하여 우선은 `/pages` 디렉토리에 추가

### 특이사항
* `turbo dev` 실행 시 `next.env.d.ts`와 'tsconfig.json' 파일의 prettier가 적용되며 파일 변경사항이 발생함.